### PR TITLE
Test cases for returning clause

### DIFF
--- a/datastore/src/test/java/org/example/store/MovieStoreTest.java
+++ b/datastore/src/test/java/org/example/store/MovieStoreTest.java
@@ -107,15 +107,60 @@ class MovieStoreTest {
 
     /**
      * Test Plan.
+     * The returned object should be non-null
+     * The returned object should have the same values as the inserted object.
+     * The returned object should have non-null id.
      * @throws SQLException
      */
     @Test
     void testSingleReturning() throws SQLException {
+        this.movieStore.delete().execute();
 
+        Movie movieToInsert = moviesToTest.get(0);
+        Movie insertedMovie = this.movieStore.insert().values(movieToInsert).returning();
+
+        Assertions.assertNotNull(insertedMovie, "Inserted Movie is null");
+
+        Assertions.assertNotNull(insertedMovie.getId(), "Inserted Movie id is null");
+
+        Assertions.assertEquals(insertedMovie.getTitle(), movieToInsert.getTitle(), "Inserted Movie title is not same");
+        Assertions.assertEquals(insertedMovie.getYearOfRelease(), movieToInsert.getYearOfRelease(), "Inserted Movie yearOfRelease is not same");
+        Assertions.assertEquals(insertedMovie.getDirectedBy(), movieToInsert.getDirectedBy(), "Inserted Movie directedBy is not same");
+        Assertions.assertEquals(insertedMovie.getImdbId(), movieToInsert.getImdbId(), "Inserted Movie imdbId is not same");
+        Assertions.assertEquals(insertedMovie.getRating(), movieToInsert.getRating(), "Inserted Movie rating is not same");
+        Assertions.assertEquals(insertedMovie.getGenre(), movieToInsert.getGenre(), "Inserted Movie genre is not same");
     }
 
+    /**
+     * Test Plan.
+     * The returned list length should be same as the inserted list length.
+     * The objects in the returned list should have the same values as the inserted objects.
+     * The objects in the returned list should be in the same order as the inserted objects.
+     * The objects in the returned list should have non-null id.
+     * @throws SQLException
+     */
     @Test
     void testMultipleReturning() throws SQLException {
+        this.movieStore.delete().execute();
 
+        List<Movie> insertedMovies = this.movieStore.insert().values(moviesToTest).returning();
+
+        Assertions.assertEquals(insertedMovies.size(), moviesToTest.size(), "Inserted Movies count is not same");
+
+        for (int i = 0; i < insertedMovies.size(); i++) {
+            Movie insertedMovie = insertedMovies.get(i);
+            Movie movieToInsert = moviesToTest.get(i);
+
+            Assertions.assertNotNull(insertedMovie, "Inserted Movie is null");
+
+            Assertions.assertNotNull(insertedMovie.getId(), "Inserted Movie id is null");
+
+            Assertions.assertEquals(insertedMovie.getTitle(), movieToInsert.getTitle(), "Inserted Movie title is not same");
+            Assertions.assertEquals(insertedMovie.getYearOfRelease(), movieToInsert.getYearOfRelease(), "Inserted Movie yearOfRelease is not same");
+            Assertions.assertEquals(insertedMovie.getDirectedBy(), movieToInsert.getDirectedBy(), "Inserted Movie directedBy is not same");
+            Assertions.assertEquals(insertedMovie.getImdbId(), movieToInsert.getImdbId(), "Inserted Movie imdbId is not same");
+            Assertions.assertEquals(insertedMovie.getRating(), movieToInsert.getRating(), "Inserted Movie rating is not same");
+            Assertions.assertEquals(insertedMovie.getGenre(), movieToInsert.getGenre(), "Inserted Movie genre is not same");
+        }
     }
 }

--- a/datastore/src/test/java/org/example/store/MovieStoreTest.java
+++ b/datastore/src/test/java/org/example/store/MovieStoreTest.java
@@ -6,7 +6,7 @@ import org.example.util.DataSourceProvider;
 import org.example.util.EncryptionUtil;
 import org.example.util.JsonUtil;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -28,7 +28,7 @@ class MovieStoreTest {
         this.movieStore = movieManager.getMovieStore();
     }
 
-    @BeforeAll
+    @BeforeEach
     void init() throws SQLException {
         this.movieStore.delete().execute();
         // Data used for testing


### PR DESCRIPTION
- Add test cases for returning clause
- Make the init method run before each test to avoid seed data collision between test cases 