### PR TITLE
[Mapper]Support for Geometric Data types (Polygon Type) #93

### DIFF
--- a/compiler/src/main/java/org/sqlcomponents/compiler/java/mapper/JavaMapper.java
+++ b/compiler/src/main/java/org/sqlcomponents/compiler/java/mapper/JavaMapper.java
@@ -67,6 +67,8 @@ public final class JavaMapper extends Mapper {
     @Override
     public String getDataType(final Column aColumn) {
         switch (aColumn.getColumnType()) {
+            case POLYGON:
+                return "org.locationtech.jts.geom.Polygon";
             case PATH:
                 return "java.lang.String";
             case MACADDR8:

--- a/compiler/src/test/java/org/sqlcomponents/compiler/java/mapper/postgresql/PGPolygonTypeTest.java
+++ b/compiler/src/test/java/org/sqlcomponents/compiler/java/mapper/postgresql/PGPolygonTypeTest.java
@@ -1,0 +1,35 @@
+package org.sqlcomponents.compiler.java.mapper.postgresql;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Polygon;
+import org.sqlcomponents.compiler.java.mapper.BaseMapperTest;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test Mappings of Polygon Types in Postgres.
+ * Ref: https://www.postgresql.org/docs/current/datatype-geometric.html
+ */
+public class PGPolygonTypeTest extends BaseMapperTest {
+    public PGPolygonTypeTest() throws IOException, SQLException {
+        super();
+    }
+
+    @Test
+    void getDataType() throws Exception {
+        assertEquals(Polygon.class, Class.forName(getDataType("a_polygon")), "Type Mismatch");
+
+    }
+}
+
+
+
+
+
+
+
+
+

--- a/compiler/src/test/java/org/sqlcomponents/compiler/java/mapper/postgresql/PGPolygonTypeTest.java
+++ b/compiler/src/test/java/org/sqlcomponents/compiler/java/mapper/postgresql/PGPolygonTypeTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test Mappings of Polygon Types in Postgres.
  * Ref: https://www.postgresql.org/docs/current/datatype-geometric.html
- */
+ */ 
 public class PGPolygonTypeTest extends BaseMapperTest {
     public PGPolygonTypeTest() throws IOException, SQLException {
         super();

--- a/core/src/main/java/org/sqlcomponents/core/model/relational/enums/ColumnType.java
+++ b/core/src/main/java/org/sqlcomponents/core/model/relational/enums/ColumnType.java
@@ -11,6 +11,10 @@ public enum ColumnType {
      * Circle column type.
      */
     CIRCLE("CIRCLE"),
+    /**
+     * POLYGON column type.
+     */
+    POLYGON("POLYGON"),
 
     /**
      * Inetaddress column type.

--- a/init.db/postgres/raja.sql
+++ b/init.db/postgres/raja.sql
@@ -39,6 +39,7 @@ CREATE TABLE raja(
     a_inet inet,
     a_circle circle,
     a_path varchar,
+    a_polygon polygon,
     UNIQUE(a_uuid),
    CONSTRAINT fk_code
       FOREIGN KEY(reference_code) 


### PR DESCRIPTION

Polygon Type
Scenario: DBA created a DDL with Polygon Type Column When the DBA runs the Compiler Then the compiler creates Polygon datatype model with appropriate size

Made changes in raja, column, mapper files in order to changes & complete task