### PR TITLE
Abstraction for DataSource is done

### DIFF
--- a/compiler/src/main/resources/template/java/ConvenienceMethods.ftl
+++ b/compiler/src/main/resources/template/java/ConvenienceMethods.ftl
@@ -42,6 +42,10 @@ We use similar to JPA syntax for all the convinient methods.
             
     }
         
+    public boolean exists(${getPrimaryKeysAsParameterString()}) throws SQLException {
+        return exists(getDataSource(),${getPrimaryKeysAsParameters()});
+    }
+
     public boolean exists(final DataSource dataSource,${getPrimaryKeysAsParameterString()}) throws SQLException {
         final String query = <@compress single_line=true>"SELECT
 		1
@@ -61,6 +65,9 @@ We use similar to JPA syntax for all the convinient methods.
 		return sqlBuilder.queryForExists().execute(dataSource);
 	}
 
+public int delete(${getPrimaryKeysAsParameterString()}) throws SQLException  {
+        return delete(getDataSource(),${getPrimaryKeysAsParameters()});
+}
 
 public int delete(final DataSource dataSource,${getPrimaryKeysAsParameterString()}) throws SQLException  {
 		final String query = <@compress single_line=true>"DELETE FROM ${table.escapedName?j_string}
@@ -82,6 +89,10 @@ public int delete(final DataSource dataSource,${getPrimaryKeysAsParameterString(
 <#assign a=addImportStatement(beanPackage+"."+name)>
 <#assign a=addImportStatement("java.util.Optional")>
     <#list table.uniqueColumns as uniqueColumn>
+    public Optional<${name}> selectBy${getUniqueKeysAsMethodSignature(uniqueColumn.name)}(${getUniqueKeysAsParameterString(uniqueColumn.name)}) throws <@throwsblock/> {
+        return selectBy${getUniqueKeysAsMethodSignature(uniqueColumn.name)}(getDataSource(),${getUniqueKeysAsParameters(uniqueColumn.name)});
+    }
+
     public Optional<${name}> selectBy${getUniqueKeysAsMethodSignature(uniqueColumn.name)}(final DataSource dataSource,${getUniqueKeysAsParameterString(uniqueColumn.name)}) throws <@throwsblock/> {
         
             final String query = <@compress single_line=true>"SELECT
@@ -100,6 +111,10 @@ public int delete(final DataSource dataSource,${getPrimaryKeysAsParameterString(
         return Optional.ofNullable(sqlBuilder.queryForOne(rs -> this.rowMapper(rs)).execute(dataSource));
 
             
+    }
+
+    public boolean existsBy${getUniqueKeysAsMethodSignature(uniqueColumn.name)}(${getUniqueKeysAsParameterString(uniqueColumn.name)}) throws <@throwsblock/> {
+        return existsBy${getUniqueKeysAsMethodSignature(uniqueColumn.name)}(getDataSource(),${getUniqueKeysAsParameters(uniqueColumn.name)});
     }
 
     public boolean existsBy${getUniqueKeysAsMethodSignature(uniqueColumn.name)}(final DataSource dataSource,${getUniqueKeysAsParameterString(uniqueColumn.name)}) throws <@throwsblock/> {
@@ -121,6 +136,25 @@ public int delete(final DataSource dataSource,${getPrimaryKeysAsParameterString(
 
     </#list>
 </#if>
+
+<#function getUniqueKeysAsParameters uniqueConstraintGroupName>
+	<#local pkAsParameterStr="">
+    <#local index=0>
+	<#list table.uniqueColumns as uniqueColumn>
+	    <#if uniqueColumn.name == uniqueConstraintGroupName>
+	        <#list uniqueColumn.columns as column>
+	            <#local property=getPropertyByColumnName(column.columnName)>
+	            <#if index == 0>
+                    <#local index=1>
+                <#else>
+                    <#local pkAsParameterStr = pkAsParameterStr + "," >
+                </#if>
+                <#local pkAsParameterStr = pkAsParameterStr + property.name >
+	        </#list>
+	    </#if>
+	</#list>
+	<#return pkAsParameterStr>
+</#function>
 
 
 <#function getUniqueKeysAsParameterString uniqueConstraintGroupName>

--- a/compiler/src/main/resources/template/java/Manager.ftl
+++ b/compiler/src/main/resources/template/java/Manager.ftl
@@ -15,6 +15,11 @@ public final class DataManager {
     private static DataManager dataManager;
 
     /**
+    * dataSource variable.
+    */
+    private DataSource dataSource;
+
+    /**
     * observer variable.
     */
     private final Observer observer;
@@ -33,14 +38,17 @@ public final class DataManager {
     </#if>
     </#list>
 
-    private DataManager(<#if encryption?has_content >
-     final Function<String, String> encryptionFunction,
-     final Function<String, String> decryptionFunction
+    private DataManager(
+     final DataSource dataSource
+     <#if encryption?has_content >
+     , final Function<String, String> encryptionFunction
+     , final Function<String, String> decryptionFunction
       <#assign a=addImportStatement("java.util.function.Function")>
-    </#if>
+     </#if>
     ) {
+        this.dataSource = dataSource;
         this.observer = new Observer();
-        this.procedure = new Procedure();
+        this.procedure = new Procedure(this);
         <#list orm.entities as entity>
         <#if !entity.type?? >
         this.${entity.name?uncap_first}Store = ${entity.name}Store
@@ -51,26 +59,97 @@ public final class DataManager {
         </#if>
         </#list>
     }
-     /**
-     * getManager method.
+
+    /**
+     * getManager method with DataSource.
+     * @param dataSource
+     <#if encryption?has_content>
      * @param encryptionFunction
      * @param decryptionFunction
+     </#if>
      * @return dataManager
      */
-    public static DataManager getManager(<#if encryption?has_content>
-    <#assign a=addImportStatement("javax.sql.DataSource")>
-     final Function<String, String> encryptionFunction,
-     final Function<String, String> decryptionFunction
-    </#if>
-                                                            ) {
+    public static DataManager getManager(
+        final DataSource dataSource
+        <#if encryption?has_content>
+        , final Function<String, String> encryptionFunction
+        , final Function<String, String> decryptionFunction
+        </#if>
+    ) {
         if (dataManager == null) {
-            dataManager = new DataManager(<#if encryption?has_content>
-             encryptionFunction,
-             decryptionFunction
-            </#if>
+            dataManager = new DataManager(
+                dataSource
+                <#if encryption?has_content>
+                , encryptionFunction
+                , decryptionFunction
+                </#if>
             );
+        } else if (dataSource != null && dataManager.dataSource == null) {
+            dataManager.dataSource = dataSource;
         }
         return dataManager;
+    }
+
+    /**
+     * getManager method without DataSource.
+     <#if encryption?has_content>
+     * @param encryptionFunction
+     * @param decryptionFunction
+     </#if>
+     * @return dataManager
+     */
+    public static DataManager getManager(
+        <#if encryption?has_content>
+        final Function<String, String> encryptionFunction
+        , final Function<String, String> decryptionFunction
+        </#if>
+    ) {
+        return getManager(
+            null
+            <#if encryption?has_content>
+            , encryptionFunction
+            , decryptionFunction
+            </#if>
+        );
+    }
+
+    <#if encryption?has_content>
+    /**
+     * getManager method with DataSource only.
+     * @param dataSource
+     * @return dataManager
+     */
+    public static DataManager getManager(final DataSource dataSource) {
+        return getManager(dataSource, null, null);
+    }
+
+    /**
+     * getManager method with no arguments.
+     * @return dataManager
+     */
+    public static DataManager getManager() {
+        return getManager(null, null, null);
+    }
+    </#if>
+
+    /**
+     * Retrieves default DataSource.
+     * @return dataSource
+     * @throws IllegalStateException if dataSource is null
+     */
+    public DataSource getDataSource() {
+        if (this.dataSource == null) {
+            throw new IllegalStateException("Default DataSource is not configured in DataManager. Pass DataSource to DataManager.getManager(dataSource, ...) or invoke statement with explicit DataSource parameter.");
+        }
+        return this.dataSource;
+    }
+
+    /**
+     * Sets default DataSource.
+     * @param dataSource
+     */
+    public void setDataSource(final DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
 

--- a/compiler/src/main/resources/template/java/Procedures.ftl
+++ b/compiler/src/main/resources/template/java/Procedures.ftl
@@ -71,7 +71,14 @@ public Procedure call() {
 public static final class Procedure {
 
 
+    private final DataManager dataManager;
+
     private Procedure() {
+        this(null);
+    }
+
+    private Procedure(final DataManager dataManager) {
+        this.dataManager = dataManager;
     }
 
     private static java.sql.ResultSet detachRefCursorResultSet(
@@ -151,6 +158,19 @@ public static final class Procedure {
     */
     <#if outNonVoidCount == 1>
     public ${getClassName(firstNonVoidOut.dataType)} ${procMethod.name}(
+    <#assign comma=false>
+    <#list procMethod.inputParameters as parameter>
+        <#if getClassName(parameter.dataType) != "Void">
+        <#if comma>, </#if>final ${getClassName(parameter.dataType)} ${parameter.name}<#assign comma=true>
+        </#if>
+    </#list>
+    ) throws SQLException {
+        if (this.dataManager == null) {
+            throw new IllegalStateException("Default DataSource is not configured in DataManager.");
+        }
+        return ${procMethod.name}(this.dataManager.getDataSource()<#list procMethod.inputParameters as parameter><#if getClassName(parameter.dataType) != "Void">, ${parameter.name}</#if></#list>);
+    }
+    public ${getClassName(firstNonVoidOut.dataType)} ${procMethod.name}(
         final DataSource dbDataSource
     <#list procMethod.inputParameters as parameter>
         <#if getClassName(parameter.dataType) != "Void">
@@ -227,6 +247,24 @@ public static final class Procedure {
     }
     <#elseif outNonVoidCount gt 1>
     public void ${procMethod.name}(
+    <#assign comma=false>
+    <#list procMethod.inputParameters as parameter>
+        <#if getClassName(parameter.dataType) != "Void">
+        <#if comma>, </#if>final ${getClassName(parameter.dataType)} ${parameter.name}<#assign comma=true>
+        </#if>
+    </#list>
+    <#list procMethod.outputParameters as parameter>
+        <#if getClassName(parameter.dataType) != "Void">
+        <#if comma>, </#if>final ${getClassName(parameter.dataType)}[] ${parameter.name}<#assign comma=true>
+        </#if>
+    </#list>
+    ) throws SQLException {
+        if (this.dataManager == null) {
+            throw new IllegalStateException("Default DataSource is not configured in DataManager.");
+        }
+        ${procMethod.name}(this.dataManager.getDataSource()<#list procMethod.inputParameters as parameter><#if getClassName(parameter.dataType) != "Void">, ${parameter.name}</#if></#list><#list procMethod.outputParameters as parameter><#if getClassName(parameter.dataType) != "Void">, ${parameter.name}</#if></#list>);
+    }
+    public void ${procMethod.name}(
         final DataSource dbDataSource
     <#list procMethod.inputParameters as parameter>
         <#if getClassName(parameter.dataType) != "Void">
@@ -263,6 +301,19 @@ public static final class Procedure {
         }
     }
     <#else>
+    public void ${procMethod.name}(
+    <#assign comma=false>
+    <#list procMethod.inputParameters as parameter>
+        <#if getClassName(parameter.dataType) != "Void">
+        <#if comma>, </#if>final ${getClassName(parameter.dataType)} ${parameter.name}<#assign comma=true>
+        </#if>
+    </#list>
+    ) throws SQLException {
+        if (this.dataManager == null) {
+            throw new IllegalStateException("Default DataSource is not configured in DataManager.");
+        }
+        ${procMethod.name}(this.dataManager.getDataSource()<#list procMethod.inputParameters as parameter><#if getClassName(parameter.dataType) != "Void">, ${parameter.name}</#if></#list>);
+    }
     public void ${procMethod.name}(
         final DataSource dbDataSource
     <#list procMethod.inputParameters as parameter>

--- a/compiler/src/main/resources/template/java/Store.ftl
+++ b/compiler/src/main/resources/template/java/Store.ftl
@@ -86,6 +86,14 @@ import java.util.stream.Collectors;
 
     }
 
+    /**
+    * Retrieves default DataSource from DataManager.
+    * @return dataSource
+    */
+    public DataSource getDataSource() {
+        return this.dataManager.getDataSource();
+    }
+
  
     <#include "method/InsertStatement.ftl">
     <#include "method/UpdateStatement.ftl">
@@ -95,7 +103,7 @@ import java.util.stream.Collectors;
     <#if table.tableType == 'TABLE' >
 
     public DataManager.DeleteStatement delete() {
-        return new DataManager.DeleteStatement("DELETE FROM ${table.escapedName?j_string}");
+        return new DataManager.DeleteStatement("DELETE FROM ${table.escapedName?j_string}", getDataSource());
     }
 
     </#if>

--- a/compiler/src/main/resources/template/java/method/DeleteStatement.ftl
+++ b/compiler/src/main/resources/template/java/method/DeleteStatement.ftl
@@ -3,9 +3,22 @@
     public static final class DeleteStatement implements Sql<Integer> {
 
         private final String sql;
+        private final DataSource defaultDataSource;
 
         public DeleteStatement(final String sql) {
+            this(sql, null);
+        }
+
+        public DeleteStatement(final String sql, final DataSource defaultDataSource) {
             this.sql = sql;
+            this.defaultDataSource = defaultDataSource;
+        }
+
+        public Integer execute() throws SQLException {
+            if (this.defaultDataSource == null) {
+                throw new IllegalStateException("Default DataSource is not configured in DataManager. Pass DataSource to execute(dataSource) or configure DataManager.getManager(dataSource, ...)");
+            }
+            return execute(this.defaultDataSource);
         }
 
         @Override
@@ -14,10 +27,10 @@
                     .execute(connection);
         }
 
-        public Sql<Integer> where(final WhereClause whereClause) {
+        public DeleteStatement where(final WhereClause whereClause) {
             final String query = this.sql
                     + ( whereClause == null ? "" : (" WHERE " + whereClause.asSql()) );
-            return SqlBuilder.sql(query);
+            return new DeleteStatement(query, this.defaultDataSource);
         }
 
         public DataManager.Statement<Value<?,?>> sql(final String sql) {

--- a/compiler/src/main/resources/template/java/method/InsertStatement.ftl
+++ b/compiler/src/main/resources/template/java/method/InsertStatement.ftl
@@ -125,6 +125,10 @@
             }
             
 
+            public int execute() throws SQLException  {
+                return execute(${name}Store.this.getDataSource());
+            }
+
             public int execute(final DataSource dataSource) throws SQLException  {
                 final String query = "<@insertquery/>";
 
@@ -136,6 +140,10 @@
             }
 
             <#if table.hasPrimaryKey>
+
+            public ${name} returning() throws <@throwsblock/>  {
+                return returning(${name}Store.this.getDataSource());
+            }
 
             public ${name} returning(final DataSource dataSource) throws <@throwsblock/>  {
 
@@ -193,6 +201,10 @@
                 this.${name?uncap_first}s = ${name?uncap_first}s;
             }
 
+            public int execute() throws SQLException  {
+                return execute(${name}Store.this.getDataSource());
+            }
+
             public int execute(final DataSource dataSource) throws SQLException  {
                 String query = "<@insertquery/>";
 
@@ -210,6 +222,10 @@
             }
 
             <#if table.hasPrimaryKey>
+
+            public List<${name}> returning() throws <@throwsblock/>  {
+                return returning(${name}Store.this.getDataSource());
+            }
 
             public List<${name}> returning(final DataSource dataSource) throws <@throwsblock/>  {
                 List<${name}> inserted${name}s = null;

--- a/compiler/src/main/resources/template/java/method/MViewRefresh.ftl
+++ b/compiler/src/main/resources/template/java/method/MViewRefresh.ftl
@@ -1,4 +1,8 @@
 <#if table.tableType == 'MATERIALIZED_VIEW' >
+    public void refresh() throws SQLException {
+      refresh(getDataSource());
+    }
+
     public void refresh(final DataSource dataSource) throws SQLException {
       final String query = "REFRESH MATERIALIZED VIEW ${table.escapedName?j_string}";
       SqlBuilder.sql(query).execute(dataSource);

--- a/compiler/src/main/resources/template/java/method/SelectStatement.ftl
+++ b/compiler/src/main/resources/template/java/method/SelectStatement.ftl
@@ -39,6 +39,10 @@ public sealed class SingleSelectStatement implements ${orm.application.rootPacka
             ${getPrimaryKeysAsSetters()}
         }
 
+        public final ${name} execute() throws <@throwsblock/> {
+            return execute(${name}Store.this.getDataSource());
+        }
+
         @Override
         public final ${name} execute(final Connection connection) throws <@throwsblock/> {
             
@@ -61,11 +65,6 @@ public sealed class SingleSelectStatement implements ${orm.application.rootPacka
 
         return sqlBuilder.queryForOne(rs -> ${name}Store.this.rowMapper(rs)).execute(connection);
 	}
-
-        
-
-
-        
 }
 
 </#if>
@@ -105,6 +104,10 @@ public sealed class SelectStatement implements ${orm.application.rootPackage}.sq
             this.whereClause = whereClause;
         }
 
+        public final List<${name}> execute() throws <@throwsblock/> {
+            return execute(${name}Store.this.getDataSource());
+        }
+
         @Override
         public final List<${name}> execute(final Connection connection) throws <@throwsblock/> {
             
@@ -118,6 +121,10 @@ public sealed class SelectStatement implements ${orm.application.rootPackage}.sq
                 return SqlBuilder.sql(query).queryForList(rs -> ${name}Store.this.rowMapper(rs)).execute(connection);
 	}
 
+        public final int count() throws SQLException {
+            return count(${name}Store.this.getDataSource());
+        }
+
         public final int count(final DataSource dataSource) throws SQLException {
 		final String query = <@compress single_line=true>"SELECT
 		COUNT(<#if primaryKeyProperties?size == 0
@@ -129,10 +136,6 @@ public sealed class SelectStatement implements ${orm.application.rootPackage}.sq
                 + ( this.whereClause == null ? "" : (" WHERE " + this.whereClause.asSql()) );
                 return SqlBuilder.sql(query).queryForInt().execute(dataSource);
 	}
-
-
-    
-
 
         public final class LimitClause  {
 
@@ -157,10 +160,13 @@ public sealed class SelectStatement implements ${orm.application.rootPackage}.sq
                 <#assign a=addImportStatement("org.springframework.data.domain.PageImpl")>
                 <#assign a=addImportStatement("org.springframework.data.domain.Pageable")>
                 public Page<${name}> execute(final Pageable pageable) throws <@throwsblock/> {
-                    return new PageImpl(this.selectStatement.execute(dataSource), pageable,
+                    return new PageImpl(this.selectStatement.execute(${name}Store.this.getDataSource()), pageable,
                                 selectStatement.count());
                 }
                 <#else>
+                public DataManager.Page<${name}> execute() throws <@throwsblock/> {
+                    return execute(${name}Store.this.getDataSource());
+                }
                 public DataManager.Page<${name}> execute(final DataSource dataSource) throws <@throwsblock/> {
                     try (Connection connection = dataSource.getConnection()) {
                         return DataManager.page(SelectStatement.this.execute(connection), count(dataSource));
@@ -188,19 +194,20 @@ public sealed class SelectStatement implements ${orm.application.rootPackage}.sq
                                 return this.limitClause.execute(pageable);
                         }
                         <#else>
+                        public DataManager.Page<${name}> execute() throws <@throwsblock/> {
+                                return this.limitClause.execute(${name}Store.this.getDataSource());
+                        }
                         public DataManager.Page<${name}> execute(final DataSource dataSource) throws <@throwsblock/> {
                                 return this.limitClause.execute(dataSource);
                         }
                         </#if>
-
-
         }
 
         }
 
 
 public final DataManager.SelectQuery<Value<?,?>,${name}> sql(final String sql) {
-            return new DataManager.SelectQuery<>(sql, rs -> ${name}Store.this.rowMapper(rs));
+            return new DataManager.SelectQuery<>(sql, rs -> ${name}Store.this.rowMapper(rs), ${name}Store.this.getDataSource());
     }
 
 

--- a/compiler/src/main/resources/template/java/method/UpdateStatement.ftl
+++ b/compiler/src/main/resources/template/java/method/UpdateStatement.ftl
@@ -86,6 +86,10 @@
                 }
 
 
+                public int execute() throws SQLException  {
+                    return execute(${name}Store.this.getDataSource());
+                }
+
                 public int execute(final DataSource dataSource) throws SQLException  {
                 
                     <@updatetquery/>
@@ -96,6 +100,10 @@
                 }
 
                 <#if table.hasPrimaryKey>
+
+                public final ${name} returning() throws <@throwsblock/>  {
+                    return returning(${name}Store.this.getDataSource());
+                }
 
                 public final ${name} returning(final DataSource dataSource) throws <@throwsblock/>  {
                     ${name} updated${name} = null ;
@@ -158,6 +166,10 @@
                     return stringBuilder.toString();
                 }
                 
+                public int execute() throws SQLException  {
+                    return execute(${name}Store.this.getDataSource());
+                }
+
                 public int execute(final DataSource dataSource) throws SQLException  {
                     
                     <@updatewithsetquery/>
@@ -169,6 +181,10 @@
                     }
 
                     return sqlBuilder.execute(dataSource);
+                }
+
+                public List<${name}> returning() throws <@throwsblock/>  {
+                    return returning(${name}Store.this.getDataSource());
                 }
 
                 public List<${name}> returning(final DataSource dataSource) throws <@throwsblock/>  {

--- a/compiler/src/main/resources/template/java/query/SelectQuery.ftl
+++ b/compiler/src/main/resources/template/java/query/SelectQuery.ftl
@@ -2,12 +2,18 @@
 
         private final String sql;
         private final RowMapper<V> rowMapper;
+        private final DataSource defaultDataSource;
 
         private final List<T> values;
 
-        public SelectQuery(final String sql,final RowMapper<V> rowMapper) {
+        public SelectQuery(final String sql, final RowMapper<V> rowMapper) {
+            this(sql, rowMapper, null);
+        }
+
+        public SelectQuery(final String sql, final RowMapper<V> rowMapper, final DataSource defaultDataSource) {
             this.sql = sql;
             this.rowMapper = rowMapper;
+            this.defaultDataSource = defaultDataSource;
             this.values = new ArrayList<>();
         }
 
@@ -15,6 +21,13 @@
         public SelectQuery<T, V> param(final T value) {
             this.values.add(value);
             return this;
+        }
+
+        public Optional<V> optional() throws SQLException {
+            if (this.defaultDataSource == null) {
+                throw new IllegalStateException("Default DataSource is not configured for SelectQuery. Pass DataSource to optional(dataSource) or construct SelectQuery with DataSource.");
+            }
+            return optional(this.defaultDataSource);
         }
 
         public Optional<V> optional(final DataSource dataSource) throws SQLException {
@@ -25,6 +38,13 @@
             }
             
             return Optional.ofNullable(sqlBuilder.queryForOne(rowMapper).execute(dataSource));
+        }
+
+        public List<V> list() throws SQLException {
+            if (this.defaultDataSource == null) {
+                throw new IllegalStateException("Default DataSource is not configured for SelectQuery. Pass DataSource to list(dataSource) or construct SelectQuery with DataSource.");
+            }
+            return list(this.defaultDataSource);
         }
 
         public List<V> list(final DataSource dataSource) throws SQLException {

--- a/compiler/src/test/java/org/sqlcomponents/compiler/java/mapper/postgresql/DataTypeTest.java
+++ b/compiler/src/test/java/org/sqlcomponents/compiler/java/mapper/postgresql/DataTypeTest.java
@@ -119,8 +119,8 @@ abstract class DataTypeTest<T> {
 
                 myTableClass = classLoader.loadClass("org.example.model.MyTable");
 
-                Method method = loadedClass.getMethod("getManager", Function.class, Function.class);
-                Object dataManager = method.invoke(null, null, null);
+                Method method = loadedClass.getMethod("getManager", DataSource.class, Function.class, Function.class);
+                Object dataManager = method.invoke(null, DATA_SOURCE, null, null);
 
                 this.myTableStoreClass = classLoader.loadClass("org.example.store.MyTableStore");
 

--- a/datastore/src/test/java/org/example/store/AccountsStoreTest.java
+++ b/datastore/src/test/java/org/example/store/AccountsStoreTest.java
@@ -19,6 +19,7 @@ class AccountsStoreTest {
         this.dataSource = DataSourceProvider.dataSource();
         DataManager dataManager =
                 DataManager.getManager(
+                        dataSource,
                         EncryptionUtil::enAnDecrypt,
                         EncryptionUtil::enAnDecrypt);
         // Stores used for testing

--- a/datastore/src/test/java/org/example/store/CountTest.java
+++ b/datastore/src/test/java/org/example/store/CountTest.java
@@ -28,6 +28,7 @@ class CountTest {
 
         DataManager dataManager =
                 DataManager.getManager(
+                        dataSource,
                         EncryptionUtil::enAnDecrypt,
                         EncryptionUtil::enAnDecrypt);
 
@@ -38,20 +39,20 @@ class CountTest {
 
     @BeforeEach
     void init() throws SQLException {
-        this.movieStore.delete().execute(dataSource);
-        this.cacheStore.delete().execute(dataSource);
+        this.movieStore.delete().execute();
+        this.cacheStore.delete().execute();
     }
 
     @Test
     void testSql() throws SQLException {
 
         // No Primary Key (Code Table)
-        this.cacheStore.insert().values(new Cache("a","b", null, null, null, null)).execute(dataSource);
-        Assertions.assertEquals(1, this.cacheStore.select().count(dataSource));
+        this.cacheStore.insert().values(new Cache("a","b", null, null, null, null)).execute();
+        Assertions.assertEquals(1, this.cacheStore.select().count());
 
         // Single Primary Key
-        this.movieStore.insert().values(new Movie(null,"Vettayan","Gyanavel")).execute(dataSource);
-        Assertions.assertEquals(1, this.movieStore.select().count(dataSource));
+        this.movieStore.insert().values(new Movie(null,"Vettayan","Gyanavel")).execute();
+        Assertions.assertEquals(1, this.movieStore.select().count());
 
         // Multiple Primary Keys
 

--- a/datastore/src/test/java/org/example/store/MovieStoreTest.java
+++ b/datastore/src/test/java/org/example/store/MovieStoreTest.java
@@ -28,6 +28,7 @@ class MovieStoreTest {
 
         DataManager dataManager =
                 DataManager.getManager(
+                        dataSource,
                         EncryptionUtil::enAnDecrypt,
                         EncryptionUtil::enAnDecrypt);
 
@@ -36,7 +37,7 @@ class MovieStoreTest {
 
     @BeforeEach
     void init() throws SQLException {
-        this.movieStore.delete().execute(dataSource);
+        this.movieStore.delete().execute();
     }
 
     @Test
@@ -45,18 +46,18 @@ class MovieStoreTest {
         Movie movie = movieStore
                 .insert()
                     .values(new Movie(null, "Inception", "Christopher Nolan"))
-                .returning(dataSource);
+                .returning();
 
-        Assertions.assertTrue(movieStore.exists(dataSource,movie.id()));
+        Assertions.assertTrue(movieStore.exists(movie.id()));
 
         movie = movieStore
                 .select(movie.id())
-                .execute(dataSource);
+                .execute();
 
         movie = movieStore
                 .select(movie.id())
                     .where(directedBy().eq("Christopher Nolan"))
-                .execute(dataSource);
+                .execute();
 
         Assertions.assertNotNull(movie);
 
@@ -68,34 +69,34 @@ class MovieStoreTest {
                         new Movie(null, "Fight Club", "David Fincher"),
                         new Movie(null, "Interstellar", "Christopher Nolan"),
                         new Movie(null, "The Social Network", "David Fincher"))
-                .returning(dataSource);
+                .returning();
 
         Assertions.assertEquals(6, movies.size());
         movie = movieStore
                 .insert()
                     .values(new Movie(null, "The Dark Knight", "Christopher Nolan"))
-                .returning(dataSource);
+                .returning();
 
         movies = movieStore
                 .select()
-                .execute(dataSource);
+                .execute();
 
         movies = movieStore
                 .select()
                     .where(directedBy().eq("Christopher Nolan")
                             .and().directedBy().eq("David Fincher"))
-                .execute(dataSource);
+                .execute();
 
         movies = movieStore
                 .select()
-                .where(title().eq("Fight Club")).execute(dataSource);
+                .where(title().eq("Fight Club")).execute();
 
 
         int updatedRecords = movieStore
                 .update()
                         .set(new Movie(null, "Fight Club", "Martyn Scorsese"))
                 .where(title().eq("Fight Club"))
-                .execute(dataSource);
+                .execute();
 
         Assertions.assertEquals(1, updatedRecords, "Update Failed");
 
@@ -103,13 +104,13 @@ class MovieStoreTest {
                 .update()
                     .set(directedBy("Martyn Scorsese"))
                     .where(title().eq("Fight Club"))
-                .execute(dataSource);
+                .execute();
 
         Assertions.assertEquals(1, updatedRecords, "Update Failed");
 
         movies = movieStore
                 .select()
-                .where(title().eq("Fight Club")).execute(dataSource);
+                .where(title().eq("Fight Club")).execute();
 
         Assertions.assertEquals("Martyn Scorsese", movies.get(0).directedBy());
 
@@ -118,7 +119,7 @@ class MovieStoreTest {
         int updatedRows = this.movieStore
                 .delete()
                     .where(directedBy().eq("Martyn Scorsese"))
-                .execute(dataSource);
+                .execute();
 
         Assertions.assertEquals(1, updatedRows);
 

--- a/datastore/src/test/java/org/example/store/ViewTest.java
+++ b/datastore/src/test/java/org/example/store/ViewTest.java
@@ -21,6 +21,7 @@ class ViewTest {
         this.dataSource = DataSourceProvider.dataSource();
         DataManager dataManager =
                 DataManager.getManager(
+                        dataSource,
                         EncryptionUtil::enAnDecrypt,
                         EncryptionUtil::enAnDecrypt);
         this.movieViewStore = dataManager.getMovieViewStore();
@@ -31,25 +32,25 @@ class ViewTest {
 
     @BeforeEach
     void init() throws SQLException {
-        this.movieStore.delete().execute(dataSource);
-        this.materializedMovieViewStore.refresh(dataSource);
+        this.movieStore.delete().execute();
+        this.materializedMovieViewStore.refresh();
         this.movieStore
                 .insert()
                 .values(new Movie(null, "Pulp Fiction", "Quentin Tarantino"),
                         new Movie(null, "The Matrix", "Lana Wachowski"))
-                .execute(dataSource);
+                .execute();
     }
 
     @Test
     void testViews() throws SQLException {
-        Assertions.assertEquals(2, this.movieViewStore.select().execute(dataSource).size());
+        Assertions.assertEquals(2, this.movieViewStore.select().execute().size());
 
         // No Data as View is not refreshed
-        Assertions.assertEquals(0, this.materializedMovieViewStore.select().execute(dataSource).size());
+        Assertions.assertEquals(0, this.materializedMovieViewStore.select().execute().size());
         // Refresh the Materialized View
-        this.materializedMovieViewStore.refresh(dataSource);
+        this.materializedMovieViewStore.refresh();
         // Data as View is now refreshed
-        Assertions.assertEquals(2, this.materializedMovieViewStore.select().execute(dataSource).size());
+        Assertions.assertEquals(2, this.materializedMovieViewStore.select().execute().size());
 
     }
 

--- a/datastore/src/test/java/org/example/storedprocedure/StoredProcedureTest.java
+++ b/datastore/src/test/java/org/example/storedprocedure/StoredProcedureTest.java
@@ -78,7 +78,7 @@ class StoredProcedureTest {
 
     private final DataSource dataSource = DATA_SOURCE;
     private final DataManager dataManager =
-            DataManager.getManager(EncryptionUtil::enAnDecrypt, EncryptionUtil::enAnDecrypt);
+            DataManager.getManager(DATA_SOURCE, EncryptionUtil::enAnDecrypt, EncryptionUtil::enAnDecrypt);
     private final CacheStore cacheStore = dataManager.getCacheStore();
     private final AccountsStore accountsStore = dataManager.getAccountsStore();
 

--- a/datastore/src/test/java/org/example/util/DataSourceProvider.java
+++ b/datastore/src/test/java/org/example/util/DataSourceProvider.java
@@ -12,7 +12,11 @@ public final class DataSourceProvider {
     public static DataSource dataSource() {
         Properties props = new Properties();
         try {
-            props.load(new FileReader("../database.properties"));
+            java.io.File propsFile = new java.io.File("database.properties");
+            if (!propsFile.exists()) {
+                propsFile = new java.io.File("../database.properties");
+            }
+            props.load(new FileReader(propsFile));
         } catch (IOException e) {
             // Unreachable
             e.printStackTrace();


### PR DESCRIPTION
⁠It appears that execute(dataSource) is rather repetitive. Would it be possible to remove that, or at least having to pass dataSource. I am curious, if the code generation used the schema from a dataSource, then the DataManager should be able to internally tie the execute to the dataSource of the schema - Tied the datasource internally.